### PR TITLE
Fixed problem with whitespaces in revision name

### DIFF
--- a/lib/android-jsc/build.gradle
+++ b/lib/android-jsc/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'maven'
 task createAAR(type: Upload) {
     def distDir = "${rootDir}/../dist"
 
-    def revision = project.findProperty("revision")
+    def revision = project.findProperty("revision").replaceAll("\\s","")
     def i18n = project.findProperty("i18n")
 
     doFirst {


### PR DESCRIPTION
On some configurations (can't tell why) subversion is adding whitespace chars at the end of revision string in start.sh script. 
This is really annoying because gradle outputs files with names like "android-jsc-r224109    .aar"
This small change should prevent that.