### PR TITLE
Use API 16 for armv7, x86 as current react-native spec

### DIFF
--- a/lib/android-jsc/build.gradle
+++ b/lib/android-jsc/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/patches/jsc.patch
+++ b/patches/jsc.patch
@@ -291,3 +291,43 @@ diff -aur target-org/webkit/Source/JavaScriptCore/CMakeLists.txt target/webkit/S
  )
 +add_definitions(-DJSC_VERSION="${JSC_VERSION}")
 
+diff -aur target-org/webkit/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp target/webkit/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+--- target-org/webkit/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp     2018-11-11 23:05:48.000000000 +0800
++++ target/webkit/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp 2018-11-12 23:39:22.000000000 +0800
+@@ -23,6 +23,10 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+
++// CUSTOMIZE_REACT_NATIVE: getline() does not implemented until Android NDK API 18.
++// Since MemoryFootprint does not being used in JSC, comment out to prevent build break.
++#if !defined(CUSTOMIZE_REACT_NATIVE)
++
+ #include "config.h"
+ #include "MemoryFootprint.h"
+
+@@ -107,3 +111,4 @@
+ }
+
+ }
++#endif // !defined(CUSTOMIZE_REACT_NATIVE)
+diff -aur target-org/webkit/Source/JavaScriptCore/Sources.txt target/webkit/Source/JavaScriptCore/Sources.txt
+--- target-org/webkit/Source/JavaScriptCore/Sources.txt 2018-11-11 23:05:40.000000000 +0800
++++ target/webkit/Source/JavaScriptCore/Sources.txt     2018-11-12 00:03:26.000000000 +0800
+@@ -1046,3 +1046,6 @@
+
+ // Derived Sources
+ yarr/YarrCanonicalizeUnicode.cpp
++
++// Polyfills
++polyfills/log2.cpp
+diff -aur /dev/null target/webkit/Source/JavaScriptCore/polyfills/log2.cpp
+--- /dev/null   2018-11-12 01:21:57.000000000 +0800
++++ target/webkit/Source/JavaScriptCore/polyfills/log2.cpp      2018-11-12 01:19:49.000000000 +0800
+@@ -0,0 +1,7 @@
++#include <math.h>
++
++#if defined(__ANDROID__) && __ANDROID_API__ < 18
++double log2(double x) {
++  return log(x) / log(2.0);
++}
++#endif

--- a/scripts/compile/all.sh
+++ b/scripts/compile/all.sh
@@ -21,6 +21,7 @@ compile_arch() {
 compile() {
   for arch in arm x86
   do
+    export ANDROID_API=$ANDROID_API_FOR_ABI_32
     export JSC_ARCH=$arch
     export ENABLE_COMPAT=1
     compile_arch
@@ -28,6 +29,7 @@ compile() {
 
   for arch in arm64 x86_64
   do
+    export ANDROID_API=$ANDROID_API_FOR_ABI_64
     export JSC_ARCH=$arch
     export ENABLE_COMPAT=0
     compile_arch

--- a/scripts/compile/common.sh
+++ b/scripts/compile/common.sh
@@ -110,7 +110,8 @@ process_switch_options "INTL"
 
 # checks
 err=false
-if ! [[ $ANDROID_API ]]; then echo "set ANDROID_API to the minimum supported Android platform version (e.g. 15)"; err=true; fi
+if ! [[ $ANDROID_API_FOR_ABI_32 ]]; then echo "set ANDROID_API_FOR_ABI_32 to the minimum supported Android platform version for arm and x86 (e.g. 16)"; err=true; fi
+if ! [[ $ANDROID_API_FOR_ABI_64 ]]; then echo "set ANDROID_API_FOR_ABI_64 to the minimum supported Android platform version for arm64 and x86_64 (e.g. 21)"; err=true; fi
 if ! [[ $FLAVOR ]]; then echo "set FLAVOR to the name of the flavor"; err=true; fi
 if ! [[ $CROSS_COMPILE_PLATFORM ]]; then echo "set JSC_ARCH to one of {arm,arm64,x86,x86_64}"; err=true; fi
 if ! [[ $ANDROID_HOME ]]; then echo "set ANDROID_HOME to android sdk dir"; err=true; fi
@@ -127,6 +128,7 @@ COMMON_LDFLAGS=" \
 -Wl,--gc-sections \
 -Wl,--exclude-libs,libgcc.a \
 -Wl,--exclude-libs,libunwind.a \
+-Wl,--no-undefined \
 "
 
 COMMON_CFLAGS=" \
@@ -141,6 +143,7 @@ COMMON_CFLAGS=" \
 -fPIC \
 -fvisibility=hidden \
 -DNDEBUG \
+-DCUSTOMIZE_REACT_NATIVE \
 $SWITCH_COMMON_CFLAGS_INTL \
 "
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-export ANDROID_API=21
+export ANDROID_API_FOR_ABI_32=16
+export ANDROID_API_FOR_ABI_64=21
 export ROOTDIR=$PWD
 export TARGETDIR=$ROOTDIR/build/target
 source $ROOTDIR/scripts/info.sh


### PR DESCRIPTION
One concern for jsc-android-buildscripts is about its minSdkVersion bumped to 21.
This PR follows current React Native Android's spec.

For armv7 and x86, the minimal API is 16.
For arm64 and x86_64, the minimal API is 21. (Android introduce 64 bits support after API 21).