### PR TITLE
Exclude unwinders from exported symbols

### DIFF
--- a/scripts/compile/common.sh
+++ b/scripts/compile/common.sh
@@ -125,6 +125,8 @@ COMMON_LDFLAGS=" \
 -Wl,--icf=safe \
 -Wl,-z,noexecstack \
 -Wl,--gc-sections \
+-Wl,--exclude-libs,libgcc.a \
+-Wl,--exclude-libs,libunwind.a \
 "
 
 COMMON_CFLAGS=" \


### PR DESCRIPTION
This PR fixes issues related to C++ exception support and uses recommended linker flags to ensure symbols from unwinders are not re-exported.

Related issues:
https://github.com/android-ndk/ndk/issues/379
https://github.com/android-ndk/ndk/issues/785
https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#common-issues

