### PR TITLE
Enable builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/jsc-android-buildscripts
+    machine: true
+    environment:
+      NDK_VERSION: r18
+      SDK_VERSION: sdk-tools-linux-3859397.zip
+      ANDROID_HOME: /home/circleci/android-sdk
+      ANDROID_NDK: /home/circleci/android-ndk
+    steps:
+      - checkout
+      - run:
+          name: install android sdk
+          command: |
+            curl --silent --show-error --location --fail --retry 3 --output /tmp/${SDK_VERSION} https://dl.google.com/android/repository/${SDK_VERSION} && \
+              mkdir -p ${ANDROID_HOME} && \
+              unzip -q /tmp/${SDK_VERSION} -d ${ANDROID_HOME} && \
+              rm /tmp/${SDK_VERSION}
+            export PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+            mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
+            yes | sdkmanager --licenses && sdkmanager --update
+            sdkmanager \
+              "tools" \
+              "platform-tools" \
+              "emulator" \
+              "extras;android;m2repository" \
+              "extras;google;m2repository" \
+              "extras;google;google_play_services"
+            sdkmanager \
+              "build-tools;25.0.3" \
+              "build-tools;27.0.3"
+            sdkmanager "platforms;android-27"
+      - run:
+          name: install android ndk
+          command: |
+            export PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${PATH}
+            mkdir /tmp/android-ndk-tmp && \
+              cd /tmp/android-ndk-tmp && \
+              wget -q https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip &&
+              unzip -q android-ndk-${NDK_VERSION}-linux-x86_64.zip && \
+              mv ./android-ndk-${NDK_VERSION} ${ANDROID_NDK} && \
+              cd ${ANDROID_NDK} && \
+              rm -rf /tmp/android-ndk-tmp
+            sdkmanager \
+              "lldb;3.0" \
+              "cmake;3.6.4111459"
+      - run:
+          name: install subversion
+          command: |
+            sudo apt-get update
+            sudo apt-get install coreutils realpath curl git subversion python-dev ruby gperf -y
+      - run: npm run clean
+      - run: npm run download
+      - run: npm run start
+      - store_artifacts:
+          path: dist/
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM gengjiawen/android-ndk
-
-RUN apt update && \
-    apt install curl git subversion python-dev ruby gperf -y && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt install -y nodejs

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -3,9 +3,8 @@
 URL="https://svn.webkit.org/repository/webkit/releases/WebKitGTK/webkit-${npm_package_config_webkitGTK}"
 ROOTDIR=$PWD
 
-export REVISION=$(svn info --show-item last-changed-revision "${URL}")
-
 INFO=$(svn info "${URL}")
+export REVISION=$(svn info "${URL}" | sed -n 's/^Revision: //p')
 CONFIG=$(node -e "console.log(require('$ROOTDIR/package.json').config)")
 APPLE_VERSION=$(svn cat "${URL}/Source/WebCore/Configurations/Version.xcconfig" | grep 'MAJOR_VERSION\s=\|MINOR_VERSION\s=\|TINY_VERSION\s=\|MICRO_VERSION\s=\|NANO_VERSION\s=')
 


### PR DESCRIPTION
CircleCI builds will make it much easier in the future to test PRs but also automate deployments, and will help verify that the binaries we publish comes from reproductible builds. Currently there is a CI running at wix which can only be accessed by a few people. Having builds run on a public CI service will make the whole process more transparent and also easier to troubleshoot in case os issues.

It took me a while to restore builds to work on CircleCI and the root cause of all the problems seemed to be docker environment. While running inside docker the builds will often crash (segfault) during random commands (clang or when running python). We also observed that strange behavior when running on our own hosts inside docker. In order for it to work I had to switch circleCI config from using docker to "machine" which runs some other notion of virtualization.
